### PR TITLE
add support for custom x-package in spec

### DIFF
--- a/output/openapi.go
+++ b/output/openapi.go
@@ -84,6 +84,16 @@ func getExtAsString(in interface{}) string {
 }
 
 func (o *OpenAPIFileContext) GetType(pkg, name string, s *openapi3.SchemaRef) string {
+	xPkg, ok := s.Value.Extensions["x-package"]
+	if ok {
+		customPkg := getExtAsString(xPkg)
+		if customPkg == "" {
+			return fmt.Sprint("INVALID x-pacakge: ", xPkg.(string))
+		}
+
+		pkg = customPkg
+	}
+
 	override, ok := s.Value.Extensions["x-go-type"]
 	if ok {
 		typeName := getExtAsString(override)

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -88,7 +88,7 @@ func (o *OpenAPIFileContext) GetType(pkg, name string, s *openapi3.SchemaRef) st
 	if ok {
 		customPkg := getExtAsString(xPkg)
 		if customPkg == "" {
-			return fmt.Sprint("INVALID x-pacakge: ", xPkg.(string))
+			return fmt.Sprint("INVALID x-package: ", xPkg.(string))
 		}
 
 		pkg = customPkg


### PR DESCRIPTION
This PR adds support for `x-package` custom extension to designate an external package for a particular `$ref` in an `openapi.yaml` spec. The example below shows that the `InternalRedirectMapping` will be in the `config` package as denoted by the `x-package` property. This custom extension will be extracted when determining the type in helper methods like `GetType`.

Example usage in spec: 

```yaml
paths:
  /api/v1/ticketingProviders:
    get:
        tags:
          - Ticket
        summary: Get ticketing providers
        operationId: getTicketingProviders
        security:
          - ApiAccess: []
        responses:
          "200":
            description: success
            content:
              application/json:
                schema:
                  type: array
                  items:
                    x-package: config
                    $ref: './config/config.yaml#/components/schemas/InternalRedirectMapping'
```