### PR TITLE
Use uint32 for PG OID columns, upgrade to pgx/v5, support for NULL-able columns

### DIFF
--- a/embed/embeds_gen.go
+++ b/embed/embeds_gen.go
@@ -2039,7 +2039,7 @@ import (
 // {{$goName}} represents a record from '{{.Schema.Name}}.{{$table}}'.
 type {{$goName}} struct {
 {{- range .Table.Columns.ByOrdinal }}
-	{{ case .Name }} {{ if .Nullable }}*{{end}}{{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` // {{ .Type }} {{ if .Nullable }}NULL{{end}}
+	{{ case .Name }} {{ if .Nullable }}*{{end}} {{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + `
 {{- end }}
 }
 

--- a/embed/embeds_gen.go
+++ b/embed/embeds_gen.go
@@ -2039,7 +2039,7 @@ import (
 // {{$goName}} represents a record from '{{.Schema.Name}}.{{$table}}'.
 type {{$goName}} struct {
 {{- range .Table.Columns.ByOrdinal }}
-	{{ case .Name }} {{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` // {{ .Type }} {{ if .Nullable }}NULL{{end}}
+	{{ case .Name }} {{ if .Nullable }}*{{end}}{{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + ` // {{ .Type }} {{ if .Nullable }}NULL{{end}}
 {{- end }}
 }
 

--- a/embed/embeds_gen.go
+++ b/embed/embeds_gen.go
@@ -2039,7 +2039,7 @@ import (
 // {{$goName}} represents a record from '{{.Schema.Name}}.{{$table}}'.
 type {{$goName}} struct {
 {{- range .Table.Columns.ByOrdinal }}
-	{{ case .Name }} {{ if .Nullable }}*{{end}} {{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + `
+	{{ case .Name }} {{ $.GetType . $.PackageName }}  ` + "`" + `json:"{{ .Name }},omitempty"` + "`" + `
 {{- end }}
 }
 
@@ -2431,9 +2431,9 @@ const FojiDotYaml = `formats:
 files:
   sql:
     files:
-      - "*/*/*.sql"
+      - "**/*.sql"
     filter:
-      - "^db*"
+      - "db/migrations/.*" # dbMate migrations
   embed:
     files:
       - "embed/*"
@@ -2441,7 +2441,7 @@ files:
       - ".*\\.go"
   api:
     files:
-      - "swagger.yaml"
+      - "openapi.yaml"
 processes:
   repo:
     processes: [ sqlRepo, dbRepo ]
@@ -2514,18 +2514,15 @@ var InitDotYamlBytes = []byte(InitDotYaml)
 const InitDotYaml = `db:
   connection: "host=localhost dbname=my_project sslmode=disable"
   filter:
-    - "*.schema_migrations"
+    - "*.schema_migrations" # dbMate migrations
 sql:
   files:
-    - "*/*.sql"
-    - "*/*/*.sql"
-    - "*/*/*/*.sql"
+    - "**/*.sql"
   filter:
-    - "db/migrations/.*"
+    - "db/migrations/.*" # dbMate migrations
 embed:
   files:
-    - "embed/*"
-    - "embed/*/*"
+    - "embed/**"
   filter:
     - "*.go"
 `

--- a/embed/embeds_gen.go
+++ b/embed/embeds_gen.go
@@ -1995,8 +1995,8 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5"
 )
 
 // DB is the common interface for database operations.
@@ -2080,7 +2080,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v5"
 
 	"{{.Params.Package}}"
 {{- range .Imports }}

--- a/foji/pgx/db.go.tpl
+++ b/foji/pgx/db.go.tpl
@@ -7,8 +7,8 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/jackc/pgconn"
-	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5"
 )
 
 // DB is the common interface for database operations.

--- a/foji/pgx/model.go.tpl
+++ b/foji/pgx/model.go.tpl
@@ -17,7 +17,7 @@ import (
 // {{$goName}} represents a record from '{{.Schema.Name}}.{{$table}}'.
 type {{$goName}} struct {
 {{- range .Table.Columns.ByOrdinal }}
-	{{ case .Name }} {{ $.GetType . $.PackageName }}  `json:"{{ .Name }},omitempty"` // {{ .Type }} {{ if .Nullable }}NULL{{end}}
+	{{ case .Name }} {{ if .Nullable }}*{{end}} {{ $.GetType . $.PackageName }}  `json:"{{ .Name }},omitempty"`
 {{- end }}
 }
 

--- a/foji/pgx/model.go.tpl
+++ b/foji/pgx/model.go.tpl
@@ -17,7 +17,7 @@ import (
 // {{$goName}} represents a record from '{{.Schema.Name}}.{{$table}}'.
 type {{$goName}} struct {
 {{- range .Table.Columns.ByOrdinal }}
-	{{ case .Name }} {{ if .Nullable }}*{{end}} {{ $.GetType . $.PackageName }}  `json:"{{ .Name }},omitempty"`
+	{{ case .Name }} {{ $.GetType . $.PackageName }}  `json:"{{ .Name }},omitempty"`
 {{- end }}
 }
 

--- a/foji/pgx/table.go.tpl
+++ b/foji/pgx/table.go.tpl
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v5"
 
 	"{{.Params.Package}}"
 {{- range .Imports }}

--- a/input/db/models.go
+++ b/input/db/models.go
@@ -21,7 +21,7 @@ type Tables []*Table
 
 // Table contains the definition of a table.
 type Table struct {
-	ID          int64
+	ID          uint32
 	Name        string      // the original name of the table in the DB
 	Type        string      // the table type (e.g. VIEW or BASE TABLE)
 	Comment     string      // the comment attached to the table
@@ -74,7 +74,7 @@ type Column struct {
 
 // Enum represents a type that has a set of allowed values.
 type Enum struct {
-	ID      int64
+	ID      uint32
 	Name    string             // the original name of the enum in the DB
 	Values  stringlist.Strings // the list of possible values for this enum
 	Comment string

--- a/input/db/pg/queries_gen.go
+++ b/input/db/pg/queries_gen.go
@@ -9,7 +9,7 @@ import (
 
 // Table represents a result from 'GetTables'.
 type Table struct {
-	ID        int64  `json:"id,omitempty"`         // postgres type: oid
+	ID        uint32 `json:"id,omitempty"`         // postgres type: oid
 	Schema    string `json:"schema,omitempty"`     // postgres type: name
 	Name      string `json:"name,omitempty"`       // postgres type: name
 	Type      string `json:"type,omitempty"`       // postgres type: text
@@ -64,7 +64,7 @@ ORDER BY schema, name`
 
 // Index represents a result from 'GetIndexes'.
 type Index struct {
-	ID        int64    `json:"id,omitempty"`         // postgres type: oid
+	ID        uint32   `json:"id,omitempty"`         // postgres type: oid
 	Schema    string   `json:"schema,omitempty"`     // postgres type: name
 	Name      string   `json:"name,omitempty"`       // postgres type: name
 	Table     string   `json:"table,omitempty"`      // postgres type: name
@@ -113,7 +113,7 @@ ORDER BY t.relname, c.relname`
 
 // Enum represents a result from 'GetEnums'.
 type Enum struct {
-	ID      int64    `json:"id,omitempty"`      // postgres type: oid
+	ID      uint32   `json:"id,omitempty"`      // postgres type: oid
 	Name    string   `json:"name,omitempty"`    // postgres type: name
 	Schema  string   `json:"schema,omitempty"`  // postgres type: name
 	Values  []string `json:"values,omitempty"`  // postgres type: _name
@@ -153,7 +153,7 @@ WHERE t.typtype = 'e'`
 
 // ForeignKey represents a result from 'GetForeignKeys'.
 type ForeignKey struct {
-	ID             int64    `json:"id,omitempty"`              // postgres type: oid
+	ID             uint32   `json:"id,omitempty"`              // postgres type: oid
 	Schema         string   `json:"schema,omitempty"`          // postgres type: name
 	Name           string   `json:"name,omitempty"`            // postgres type: name
 	Table          string   `json:"table,omitempty"`           // postgres type: name

--- a/pg/repo_gen.go
+++ b/pg/repo_gen.go
@@ -7,8 +7,8 @@ import (
 	"database/sql"
 	"errors"
 
-	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 )
 
 // DB is the common interface for database operations.


### PR DESCRIPTION
When running PG-dependent welders, data for several metadata queries could not be mapped to go structs because PGX row Scan was failing on the OID type.
Example: pg_class.oid
Error message: 9:25AM FTL Welding error="parsing db schema: GetTables:GetTables.Scan:can't scan into dest[0]: cannot scan oid (OID 26) in binary format into *int64"

Upgrade generated code to use pgx/v5 instead of pgx/v4 for compatibility with kit.

Support for NULL-able column mapping to go by (e.g. TEXT NULL maps to *string).