### PR TITLE
Add support for top level enum schemas and parameters

### DIFF
--- a/cfg/version.go
+++ b/cfg/version.go
@@ -1,5 +1,5 @@
 package cfg
 
-const version = "0.1.18"
+const version = "0.1.19"
 
 func Version() string { return version }

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -5,7 +5,7 @@
     {{- $package := .RuntimeParams.package -}}
     {{- if not (empty ($.OpSecurity $op)) }} user *{{ $.CheckPackage $.Params.Auth $package -}},{{- end }}
     {{- range $param := $.OpParams $path $op -}}
-		{{ $typeName := (print $op.OperationID " " $param.Value.In " " $param.Value.Name) -}}
+		{{ $typeName := (print $op.OperationID " " $param.Value.Name) -}}
 		{{- if notEmpty $param.Ref -}}
 			{{- $typeName = trimPrefix "#/components/parameters/" $param.Ref -}}
 		{{- end -}}
@@ -26,7 +26,7 @@
     {{- $param := .RuntimeParams.param }}
     {{- $package := .RuntimeParams.package }}
 	{{- $isEnum := $.ParamIsEnum $param }}
-	{{ $typeName := (print $op.OperationID " " $param.Value.In " " $param.Value.Name) -}}
+	{{ $typeName := (print $op.OperationID " " $param.Value.Name) -}}
 	{{- if notEmpty $param.Ref -}}
 		{{- $typeName = trimPrefix "#/components/parameters/" $param.Ref -}}
 	{{- end -}}

--- a/foji/openapi/model.go.tpl
+++ b/foji/openapi/model.go.tpl
@@ -345,7 +345,7 @@ var ErrMissingRequiredField = errors.New("missing required field")
 
         {{- /* Inline Params */ -}}
         {{- range $param := $.OpParams $path $op }}
-            {{- template "paramDeclaration" ($.WithParams "param" $param "name" (print $op.OperationID " " $param.Value.In " " $param.Value.Name) "label" (print "Op: " $op.OperationID " Param: "))}}
+            {{- template "paramDeclaration" ($.WithParams "param" $param "name" (print $op.OperationID " " $param.Value.Name) "label" (print "Op: " $op.OperationID " Param: "))}}
         {{- end }}
     {{- end }}
 {{- end }}

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -188,7 +188,7 @@ func (o *OpenAPIFileContext) GetType(currentPackage, name string, s *openapi3.Sc
 
 func (o *OpenAPIFileContext) EnumName(name string) string {
 	// TODO: Support override via template
-	return o.PackageName() + "." + kace.Pascal(name) // + "Enum"
+	return o.PackageName() + "." + kace.Pascal(name)
 }
 
 func (o *OpenAPIFileContext) EnumNew(name string) string {

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -188,7 +188,7 @@ func (o *OpenAPIFileContext) GetType(currentPackage, name string, s *openapi3.Sc
 
 func (o *OpenAPIFileContext) EnumName(name string) string {
 	// TODO: Support override via template
-	return o.PackageName() + "." + kace.Pascal(name) + "Enum"
+	return o.PackageName() + "." + kace.Pascal(name) // + "Enum"
 }
 
 func (o *OpenAPIFileContext) EnumNew(name string) string {

--- a/output/openapi_test.go
+++ b/output/openapi_test.go
@@ -36,7 +36,7 @@ func TestGetType(t *testing.T) {
 		{"EmptyAlias", "local", "myOverride"},
 		{"Foo.bad", "local", "INVALID x-go-type: map[foo:bar]"},
 		{"Foo", "local", "Foo"},
-		{"Complex.status", "local", "ComplexStatusEnum"},
+		{"Complex.status", "local", "ComplexStatus"},
 		{"Complex.main", "local", "Main"},
 		{"Complex.nests", "local", "[]Nest"},
 		{"Complex", "local", "Complex"},

--- a/runtime/funcs.go
+++ b/runtime/funcs.go
@@ -44,6 +44,8 @@ var Funcs = map[string]any{
 	"strIndex":     strings.Index,
 	"trimLeft":     strings.TrimLeft,
 	"trimRight":    strings.TrimRight,
+	"trimPrefix":   strings.TrimPrefix,
+	"trimSuffix":   strings.TrimSuffix,
 
 	// Inflection
 	"pluralName":       inflection.Plural,

--- a/tests/example/openapi.yaml
+++ b/tests/example/openapi.yaml
@@ -130,6 +130,29 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
+  /examples/test:
+    get:
+      operationId: getTest
+      parameters:
+        - name: vehicle
+          in: query
+          required: true
+          schema:
+            type: string
+            enum:
+              - car
+              - truck
+              - bike
+        - $ref: "#/components/parameters/PlayerIdQuery"
+        - $ref: "#/components/parameters/ColorQuery"
+        - $ref: "#/components/parameters/SeasonQuery"
+      responses:
+        "200":
+          description: 'Example'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Example"
 
 components:
   parameters:
@@ -148,6 +171,29 @@ components:
       required: true
       schema:
         type: string
+    PlayerIdQuery:
+      name: playerId
+      in: query
+      description: playerId
+      required: true
+      schema:
+        $ref: "#/components/schemas/PlayerId"
+    ColorQuery:
+      name: color
+      in: query
+      required: true
+      schema:
+        type: string
+        enum:
+          - red
+          - green
+          - blue
+    SeasonQuery:
+      name: season
+      in: path
+      required: true
+      schema:
+        $ref: "#/components/schemas/Season"
   schemas:
     Examples:
       type: object
@@ -167,5 +213,94 @@ components:
           format: uuid
         name:
           type: string
+        playerId:
+          $ref: "#/components/schemas/PlayerId"
+
       required:
         - id
+
+    PlayerId:
+      type: string
+      format: uuid
+
+    Season:
+      type: string
+      enum:
+        - spring
+        - summer
+        - fall
+        - winter
+
+#test out nested types
+    XArrayEnum:
+      type: array
+      items:
+        type: string
+        enum:
+          - option_a
+          - option_b
+          - option_c
+
+
+    XArrayObjectEnum:
+      type: array
+      items:
+        type: object
+        properties:
+          options:
+            type: string
+            enum:
+              - option_a
+              - option_b
+              - option_c
+
+    XArrayObjectArrayEnum:
+      type: array
+      items:
+        type: object
+        properties:
+          list:
+            type: array
+            items:
+              type: string
+              enum:
+                - option_a
+                - option_b
+                - option_c
+
+    XObjectEnum:
+      type: object
+      properties:
+        options:
+          type: string
+          enum:
+            - option_a
+            - option_b
+            - option_c
+
+    XObjectArrayEnum:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+            enum:
+              - option_a
+              - option_b
+              - option_c
+
+    XObjectArrayObjectEnum:
+      type: object
+      properties:
+        list:
+          type: array
+          items:
+            type: object
+            properties:
+              options:
+                type: string
+                enum:
+                  - option_a
+                  - option_b
+                  - option_c

--- a/tests/example/service.go
+++ b/tests/example/service.go
@@ -25,6 +25,6 @@ func (s *Service) GetExampleQuery(ctx context.Context, k1 string, k2 uuid.UUID, 
 	return nil, nil
 }
 
-func (s *Service) GetTest(ctx context.Context, vehicle GetTestQueryVehicle, playerID uuid.UUID, color ColorQuery, season Season) (*Example, error) {
+func (s *Service) GetTest(ctx context.Context, vehicle GetTestVehicle, playerID uuid.UUID, color ColorQuery, season Season) (*Example, error) {
 	return nil, nil
 }

--- a/tests/example/service.go
+++ b/tests/example/service.go
@@ -24,3 +24,7 @@ func (s *Service) GetExampleOptional(ctx context.Context, k1 *string, k2 *uuid.U
 func (s *Service) GetExampleQuery(ctx context.Context, k1 string, k2 uuid.UUID, k3 time.Time, k4 int32, k5 int64) (*Example, error) {
 	return nil, nil
 }
+
+func (s *Service) GetTest(ctx context.Context, vehicle GetTestQueryVehicle, playerID uuid.UUID, color ColorQuery, season Season) (*Example, error) {
+	return nil, nil
+}


### PR DESCRIPTION
inlined route parameters with inlined enums use the name field as the enum name prefixed with the OpName. 
```
  /examples/test:
    get:
      operationId: getTest
      parameters:
        - name: vehicle
          in: query
          required: true
          schema:
            type: string
            enum:
              - car
              - truck
              - bike
      responses:
        "200":
          description: 'Example'
```

Generates: `type GetTestVehicle int8`

If that parameter was defined in the "#/components/parameters/` section it generated a type using the name field
```
    ColorQuery
      name: color
      in: query
      required: true
      schema:
        type: string
        enum:
          - red
          - green
          - blue
```

Generated: `type Color int8` which only worked if one route used that type.

In addition the templates now support nested objects, arrays, enum better.