### PR TITLE
Fix enum with default param generating on same line with comment

### DIFF
--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -62,6 +62,7 @@
         {{- end -}}
     {{- end -}}
 {{- goDoc $param.Value.Description }}
+
 	{{- if eq $param.Value.Schema.Value.Type "array" }}
 	{{ goToken (camel $param.Value.Name) }}, _, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}
 		{{- if $isArrayEnum -}}, {{ $enumNew  }}{{- end -}})
@@ -89,7 +90,6 @@
 
 	{{- else if $hasDefault }}
 	{{- if $isEnum -}}
-
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}, {{ $enumNew  }})
 	{{else -}}
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }})

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -89,7 +89,7 @@
 
 	{{- else if $hasDefault }}
 	{{- if $isEnum -}}
-	    // Enum HasDefault
+
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}, {{ $enumNew  }})
 	{{else -}}
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }})

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -61,7 +61,7 @@
             {{- $getRequiredParamFunction = "GetString" -}}
         {{- end -}}
     {{- end -}}
-{{- goDoc $param.Value.Description "\n" }}
+{{- goDoc $param.Value.Description }}
 	{{- if eq $param.Value.Schema.Value.Type "array" }}
 	{{ goToken (camel $param.Value.Name) }}, _, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}
 		{{- if $isArrayEnum -}}, {{ $enumNew  }}{{- end -}})
@@ -88,9 +88,9 @@
 
 
 	{{- else if $hasDefault }}
-	{{- if $isEnum -}}
+	{{- if $isEnum }}
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}, {{ $enumNew  }})
-	{{else -}}
+	{{else}}
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }})
 	{{- end }}
 	if err != nil {

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -61,8 +61,7 @@
             {{- $getRequiredParamFunction = "GetString" -}}
         {{- end -}}
     {{- end -}}
-{{- goDoc $param.Value.Description }}
-
+{{- goDoc $param.Value.Description -}}
 	{{- if eq $param.Value.Schema.Value.Type "array" }}
 	{{ goToken (camel $param.Value.Name) }}, _, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}
 		{{- if $isArrayEnum -}}, {{ $enumNew  }}{{- end -}})

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -61,7 +61,7 @@
             {{- $getRequiredParamFunction = "GetString" -}}
         {{- end -}}
     {{- end -}}
-{{- goDoc $param.Value.Description -}}
+{{- goDoc $param.Value.Description "\n" }}
 	{{- if eq $param.Value.Schema.Value.Type "array" }}
 	{{ goToken (camel $param.Value.Name) }}, _, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}
 		{{- if $isArrayEnum -}}, {{ $enumNew  }}{{- end -}})

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -89,6 +89,7 @@
 
 	{{- else if $hasDefault }}
 	{{- if $isEnum -}}
+	    // Enum HasDefault
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }}, {{ $enumNew  }})
 	{{else -}}
 		{{ goToken (camel $param.Value.Name) }}, ok, err := params.{{ $getRequiredParamFunction }}(r, "{{ $param.Value.Name }}", {{ $required }})


### PR DESCRIPTION
When using enum for a param with a default, the generated comment and code to fetch the param were generated on one line and lead to build errors in the project using foji.  In analytics I added this parameter definition:

```
    timeBucketSize:
      name: timeBucketSize
      in: query
      required: false
      description: Time bucket size
      schema:
        type: string
        default: 30minutes
        enum:
          - 15minutes
          - 30minutes
```

Which was leading to this code being generated:

`// Time bucket sizetimeBucketSize, ok, err := params.GetEnum(r, "timeBucketSize", false, NewTimeBucketSize)`

I am modifying foji to apply a newline between the comment and the generated param.