### PR TITLE
nested and allOf object fixes

### DIFF
--- a/cfg/version.go
+++ b/cfg/version.go
@@ -1,5 +1,5 @@
 package cfg
 
-const version = "0.3.2"
+const version = "0.3.3"
 
 func Version() string { return version }

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -13,7 +13,7 @@
         {{- if $.ParamIsOptionalType $param }} *{{ end }} {{ $.GetType $package $typeName $param.Value.Schema }},
     {{- end -}}
     {{- if isNotNil $body}}
-        {{- $type := $.GetType $package (print $op.OperationID "Request") $body.Schema }} body {{ $type  -}}
+        {{- $type := $.GetType $package (print $op.OperationID " Request") $body.Schema }} body {{ $type  -}}
     {{- end -}}
 	) (
     {{- $response := $.GetOpHappyResponseType $package .RuntimeParams.op}}
@@ -305,7 +305,7 @@ func (h OpenAPIHandlers) {{ pascal $op.OperationID}}(w http.ResponseWriter, r *h
 
         {{- $hasBody := not (empty $opBody)}}
 		{{- if $hasBody }}
-			{{- $bodyType := $.GetType $package (print (pascal $op.OperationID) "Request") $opBody.Schema}}
+			{{- $bodyType := $.GetType $package (print $op.OperationID " Request") $opBody.Schema}}
 			{{- if $opBody.IsJson }}
 
 	var body {{ $bodyType }}

--- a/foji/openapi/model.go.tpl
+++ b/foji/openapi/model.go.tpl
@@ -188,7 +188,7 @@ func (e {{ $enumType }}) MarshalJSON() ([]byte, error) {
         {{- $label := .RuntimeParams.label }}
         {{- template "enum" ($.WithParams "name" $key "schema" $schema "description" (print $label " : " $key ))}}
 
-    {{- else if $schema.Value.Type.Permits "object"}}
+    {{- else if and ($schema.Value.Type.Permits "object") (gt (len ($.SchemaProperties $schema true)) 0) }}
 type {{ pascal $key }} struct {
     {{- range $field, $schemaProp := $.SchemaProperties $schema false}}
         {{- $isRequired := $.IsRequiredProperty $field $schema -}}
@@ -397,7 +397,7 @@ var ErrMissingRequiredField = errors.New("missing required field")
         {{- /* Inline Request */ -}}
         {{- $bodySchema := $.GetRequestBodyLocal $op}}
         {{- if $.SchemaIsComplex $bodySchema -}}
-            {{- template "typeDeclaration" ($.WithParams "key" (print $op.OperationID "Request") "schema" $bodySchema "label" (print $op.OperationID " Body") )}}
+            {{- template "typeDeclaration" ($.WithParams "key" (print $op.OperationID " Request") "schema" $bodySchema "label" (print $op.OperationID " Body") )}}
         {{- end }}
 
         {{- /* Inline Response */ -}}

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -453,6 +453,10 @@ func (o *OpenAPIFileContext) SchemaIsComplex(schema *openapi3.SchemaRef) bool {
 		return true
 	}
 
+	if schema.Value.AllOf != nil && len(schema.Value.AllOf) > 0 {
+		return true
+	}
+
 	if !schema.Value.Type.Is("array") {
 		return false
 	}

--- a/tests/example/openapi.yaml
+++ b/tests/example/openapi.yaml
@@ -180,7 +180,50 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Example"
-
+  /examples/inlinedAllOf:
+    post:
+      operationId: AddInlinedAllOf
+      requestBody:
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/Foo'
+                - type: object
+                  properties:
+                    special:
+                      type: boolean
+        required: false
+      responses:
+        "200":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FooBar'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
+  /examples/inlinedBody:
+    post:
+      operationId: AddInlinedBody
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                special:
+                  type: boolean
+        required: false
+      responses:
+        "200":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FooBar'
+        default:
+          $ref: '#/components/responses/ErrorResponse'
 components:
   parameters:
     IdParam:
@@ -232,7 +275,23 @@ components:
       required: true
       schema:
         $ref: "#/components/schemas/Season"
+  responses:
+    ErrorResponse:
+      description: There was an error processing the request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/errorV1'
   schemas:
+    errorV1:
+      title: Error Response
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      description: Standard error format
     Examples:
       type: object
       properties:
@@ -473,3 +532,28 @@ components:
         seniority:
           pattern: (^[1-9]\d*$)
           type: string
+
+    NamedObject:
+      type: object
+      description: Named object
+
+    Foo:
+        type: object
+        properties:
+           foo:
+              type: string
+
+    Bar:
+      type: object
+      properties:
+        bar:
+          type: string
+
+    FooBar:
+      allOf:
+        - $ref: "#/components/schemas/Foo"
+        - $ref: "#/components/schemas/Bar"
+        - type: object
+        - properties:
+            buzz:
+              type: string

--- a/tests/example/service.go
+++ b/tests/example/service.go
@@ -13,6 +13,14 @@ func (s *Service) GetExamples(ctx context.Context) (*Examples, error) {
 	return nil, nil
 }
 
+func (s *Service) AddInlinedAllOf(ctx context.Context, body AddInlinedAllOfRequest) (*FooBar, error) {
+	return nil, nil
+}
+
+func (s *Service) AddInlinedBody(ctx context.Context, body AddInlinedBodyRequest) (*FooBar, error) {
+	return nil, nil
+}
+
 func (s *Service) GetExampleParams(ctx context.Context, k1 string, k2 uuid.UUID, k3 time.Time, k4 int32, k5 int64, enumTest GetExampleParamsEnumTest) (*Example, error) {
 	return nil, nil
 }


### PR DESCRIPTION
- empty object types now alias to `map[string]any` instead of `struct {}`
- inline request and response naming is more consistent by prefixing with a space
- `SchemaIsComplex` updated to also check for `allOf`