### PR TITLE
LP-68: check err returned by http.Request.Cookie

### DIFF
--- a/foji/openapi/auth.go.tpl
+++ b/foji/openapi/auth.go.tpl
@@ -73,8 +73,8 @@ func {{ pascal $security }}Auth(fn {{if eq $value.Value.Scheme "basic"}}Basic{{e
 			return nil, httputil.ErrUnauthorized
 		}
         {{- else if eq $value.Value.In "cookie" }}
-		cookie := r.Cookie("{{$value.Value.Name}}")
-		if cookie == nil || len(cookie.Value) == 0 {
+		cookie, err := r.Cookie("{{$value.Value.Name}}")
+		if err != nil || cookie == nil || len(cookie.Value) == 0 {
 			return nil, httputil.ErrUnauthorized
 		}
 


### PR DESCRIPTION
The current auth template generates code that doesn't compile for
Cookie type openapi auth. I believe this dates from when this code
was rewritten from fastAPI (which has a Cookie function with no err
returned), but was never tested because cookie auth is not used.

This code gets and checks the returned error.