### PR TITLE
Add support for response headers to OpenAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ rest-client.private.env.json
 http-client.private.env.json
 .DS_Store
 scratch/
+tests/*/*_gen.go

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -18,7 +18,7 @@
 	) (
     {{- $response := $.GetOpHappyResponseType $package .RuntimeParams.op}}
     {{- if notEmpty $response}}{{ $.CheckPackage $response $package}}, {{ end }}
-	{{- range ($.GetOpHappyResponseHeaders $package .RuntimeParams.op) }}string, {{ end -}}
+	{{- if gt (len ($.GetOpHappyResponseHeaders $package .RuntimeParams.op)) 0 }}http.Header, {{ end -}}
 	error)
 {{- end -}}
 
@@ -340,8 +340,8 @@ func (h OpenAPIHandlers) {{ pascal $op.OperationID}}(w http.ResponseWriter, r *h
         {{- end -}}
 
         {{- $responseGoType := $opResponse.GoType}}
-        {{ if notEmpty $responseGoType }}response, {{- end -}}
-        {{- range $header := $opResponse.Headers -}}{{ camel $header }}, {{- end -}}
+        {{ if notEmpty $responseGoType }}response, {{ end -}}
+        {{- if gt (len $opResponse.Headers) 0 -}}headers, {{ end -}}
 	err {{  if or (notEmpty $responseGoType) (gt (len $opResponse.Headers) 0 ) }}:{{ end }}= h.ops.{{ pascal $op.OperationID}}(r.Context(),
         {{- if not (empty $securityList) }} user,{{- end -}}
         {{- range $param := $.OpParams $path $op}} {{ goToken (camel $param.Value.Name) }},{{- end -}}
@@ -355,8 +355,8 @@ func (h OpenAPIHandlers) {{ pascal $op.OperationID}}(w http.ResponseWriter, r *h
 	}
 
 
-	{{- range $header := $opResponse.Headers }}
-	r.Header.Add("{{$header}}", {{ camel $header }})
+	{{- if gt (len $opResponse.Headers) 0 }}
+	r.Header = headers
 	{{- end -}}
 
         {{- $key := $.GetOpHappyResponseKey $op }}

--- a/foji/openapi/handler.go.tpl
+++ b/foji/openapi/handler.go.tpl
@@ -355,9 +355,14 @@ func (h OpenAPIHandlers) {{ pascal $op.OperationID}}(w http.ResponseWriter, r *h
 	}
 
 
-	{{- if gt (len $opResponse.Headers) 0 }}
-	r.Header = headers
-	{{- end -}}
+	{{- range $header := $opResponse.Headers }}
+	{{ camel $header }} := headers.Values("{{ $header }}")
+	for _, v := range {{ camel $header }} {
+		if v != "" {
+			w.Header().Add("{{ $header }}", v)
+		}
+	}
+	{{- end }}
 
         {{- $key := $.GetOpHappyResponseKey $op }}
         {{- if notEmpty $responseGoType }}

--- a/foji/openapi/service.go.tpl
+++ b/foji/openapi/service.go.tpl
@@ -18,7 +18,7 @@
 	) (
     {{- $response := $.GetOpHappyResponseType $package .RuntimeParams.op}}
     {{- if notEmpty $response}}{{ $.CheckPackage $response $package}}, {{ end }}
-	{{- range ($.GetOpHappyResponseHeaders $package .RuntimeParams.op) }}string, {{ end -}}
+	{{- if gt (len ($.GetOpHappyResponseHeaders $package .RuntimeParams.op)) 0 }}http.Header, {{ end -}}
 	error)
 {{- end -}}
 
@@ -61,7 +61,7 @@ func (s *Service) {{ pascal $op.OperationID}}(ctx context.Context,
 	{{- $response := $.GetOpHappyResponseType $.PackageName $op}}
     return 
 	{{- if notEmpty $response -}}nil, {{ end -}}
-    {{- range ($.GetOpHappyResponseHeaders $.PackageName $op) -}}"", {{ end -}} 
+    {{- if gt (len ($.GetOpHappyResponseHeaders $.PackageName $op)) 0 -}}http.Header{}, {{ end -}} 
 	ErrNotImplemented
 }
 	{{- end }}

--- a/foji/openapi/service.go.tpl
+++ b/foji/openapi/service.go.tpl
@@ -17,7 +17,9 @@
     {{- end -}}
 	) (
     {{- $response := $.GetOpHappyResponseType $package .RuntimeParams.op}}
-    {{- if notEmpty $response}}{{ $.CheckPackage $response $package}}, {{ end }}error)
+    {{- if notEmpty $response}}{{ $.CheckPackage $response $package}}, {{ end }}
+	{{- range ($.GetOpHappyResponseHeaders $package .RuntimeParams.op) }}string, {{ end -}}
+	error)
 {{- end -}}
 
 package {{ .PackageName }}
@@ -57,11 +59,10 @@ type Service struct {
 func (s *Service) {{ pascal $op.OperationID}}(ctx context.Context,
 	{{- template "methodSignature" ($.WithParams "op" $op "path" $path "package" $.PackageName) }}{
 	{{- $response := $.GetOpHappyResponseType $.PackageName $op}}
-	{{- if notEmpty $response }}
-	return nil, ErrNotImplemented
-	{{- else }}
-	return ErrNotImplemented
-	{{- end }}
+    return 
+	{{- if notEmpty $response -}}nil, {{ end -}}
+    {{- range ($.GetOpHappyResponseHeaders $.PackageName $op) -}}"", {{ end -}} 
+	ErrNotImplemented
 }
 	{{- end }}
 {{- end }}

--- a/output/opcontent.go
+++ b/output/opcontent.go
@@ -49,6 +49,7 @@ type OpResponse struct {
 	MimeType
 	MediaType *openapi3.MediaType
 	GoType    string
+	Headers   []string
 }
 
 type OpBody struct {

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -392,7 +393,7 @@ func (o *OpenAPIFileContext) GetOpHappyResponse(pkg string, op *openapi3.Operati
 
 	happyKey := "200"
 	for key, r := range op.Responses.Map() {
-		if len(key) == 3 && key[0] == '2' {
+		if len(key) == 3 && key[0] == '2' || key[0] == '3' {
 			happyKey = key
 
 			for _, mimeType := range supportedResponseContentTypes {
@@ -412,9 +413,20 @@ func (o *OpenAPIFileContext) GetOpHappyResponse(pkg string, op *openapi3.Operati
 						goType = "*" + t
 					}
 
-					return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType}
+					if r.Value.Headers != nil {
+						return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: slices.Collect(maps.Keys(r.Value.Headers))}
+					}
+
+					return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: []string{}}
 				}
 			}
+		}
+	}
+
+	// No response with a supported content type found, but maybe there's a response with headers only
+	for key, r := range op.Responses.Map() {
+		if len(key) == 3 && key[0] == '2' || key[0] == '3' && r.Value.Headers != nil && len(r.Value.Headers) > 0 {
+			return OpResponse{Key: key, MimeType: "", MediaType: nil, GoType: "", Headers: slices.Collect(maps.Keys(r.Value.Headers))}
 		}
 	}
 
@@ -519,6 +531,11 @@ func (o *OpenAPIFileContext) GetOpHappyResponseMimeType(op *openapi3.Operation) 
 func (o *OpenAPIFileContext) GetOpHappyResponseType(pkg string, op *openapi3.Operation) string {
 	opResponse := o.GetOpHappyResponse(pkg, op)
 	return opResponse.GoType
+}
+
+func (o *OpenAPIFileContext) GetOpHappyResponseHeaders(pkg string, op *openapi3.Operation) []string {
+	opResponse := o.GetOpHappyResponse(pkg, op)
+	return opResponse.Headers
 }
 
 /* Auth Focused Helpers */

--- a/output/openapi.go
+++ b/output/openapi.go
@@ -425,7 +425,7 @@ func (o *OpenAPIFileContext) GetOpHappyResponse(pkg string, op *openapi3.Operati
 
 	// No response with a supported content type found, but maybe there's a response with headers only
 	for key, r := range op.Responses.Map() {
-		if len(key) == 3 && key[0] == '2' || key[0] == '3' && r.Value.Headers != nil && len(r.Value.Headers) > 0 {
+		if len(key) == 3 && (key[0] == '2' || key[0] == '3') && len(r.Value.Headers) > 0 {
 			return OpResponse{Key: key, MimeType: "", MediaType: nil, GoType: "", Headers: slices.Collect(maps.Keys(r.Value.Headers))}
 		}
 	}

--- a/runtime/funcs.go
+++ b/runtime/funcs.go
@@ -218,10 +218,6 @@ func NotEmpty(in string) bool {
 	return len(in) > 0
 }
 
-func Len(in []any) int {
-	return len(in)
-}
-
 // IsNil returns true if the input or referenced object is nil.
 func IsNil(i any) bool {
 	return (*[2]uintptr)(unsafe.Pointer(&i))[1] == 0

--- a/runtime/funcs.go
+++ b/runtime/funcs.go
@@ -218,6 +218,10 @@ func NotEmpty(in string) bool {
 	return len(in) > 0
 }
 
+func Len(in []any) int {
+	return len(in)
+}
+
 // IsNil returns true if the input or referenced object is nil.
 func IsNil(i any) bool {
 	return (*[2]uintptr)(unsafe.Pointer(&i))[1] == 0

--- a/tests/example/openapi.yaml
+++ b/tests/example/openapi.yaml
@@ -331,6 +331,18 @@ paths:
                 $ref: '#/components/schemas/FooBar'
         default:
           $ref: '#/components/responses/ErrorResponse'
+  /examples/header:
+    get:
+      operationId: HeaderResponse
+      description: Check header responses
+      responses:
+        "200":
+          description: OK
+          headers:
+            Location:
+              description: Redirect URL
+              schema:
+                type: string
 components:
   parameters:
     IdParam:

--- a/tests/example/service.go
+++ b/tests/example/service.go
@@ -2,6 +2,7 @@ package example
 
 import (
 	"context"
+	"net/http"
 	"time"
 
 	"github.com/google/uuid"
@@ -42,5 +43,9 @@ func (s *Service) GetExampleQuery(ctx context.Context, k1 string, k2 uuid.UUID, 
 }
 
 func (s *Service) GetTest(ctx context.Context, vehicle GetTestVehicle, vehicleDefault GetTestVehicleDefault, playerID uuid.UUID, color ColorQuery, colorDefault ColorQueryDefault, season Season) (*Example, error) {
+	return nil, nil
+}
+
+func (s *Service) HeaderResponse(ctx context.Context) (http.Header, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Note that this also allows 3xx as successful responses! This is because the primary use case for this feature is setting Location header on redirects.