### PR TITLE
openapi: support defaults without required fields

### DIFF
--- a/foji/openapi/model.go.tpl
+++ b/foji/openapi/model.go.tpl
@@ -267,10 +267,10 @@ var {{ camel $key }}Pattern = regexp.MustCompile(`{{ $schema.Value.Pattern }}`)
     {{- end -}}
 
 {{if eq $mediaType "application/json" }}
-    {{- if or $hasValidation $schema.Value.Required}}
+    {{- if or $hasValidation $schema.Value.Required (.SchemaPropertiesHaveDefaults $schema)}}
 
 func (p *{{ pascal $key }}) UnmarshalJSON(b []byte) error {
-        {{- if $schema.Value.Required }}
+        {{- if or $schema.Value.Required (.SchemaPropertiesHaveDefaults $schema) }}
     var requiredCheck map[string]any
 
     if err := json.Unmarshal(b, &requiredCheck); err != nil {

--- a/tests/example/model_test.go
+++ b/tests/example/model_test.go
@@ -197,3 +197,53 @@ func TestAddFormRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultsWithoutRequiredFields(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Raw      string
+		Expected DefaultWithoutRequired
+	}{
+		{Name: "minimal", Raw: `{}`, Expected: DefaultWithoutRequired{F1: "surprise!"}},
+		{Name: "maximal", Raw: `{"f1": "BOO!"}`, Expected: DefaultWithoutRequired{F1: "BOO!"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var actual DefaultWithoutRequired
+			err := json.Unmarshal([]byte(tc.Raw), &actual)
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}
+
+func TestNotRequiredWithValidation(t *testing.T) {
+	testCases := []struct {
+		Name     string
+		Raw      string
+		Expected NotRequiredWithValidation
+		ErrorMsg string
+	}{
+		//{Name: "minimal", Raw: `{}`, Expected: NotRequiredWithValidation{}}, //TODO: skip validation of optional fields
+		{Name: "maximal", Raw: `{"f1": ["a", "b"]}`, Expected: NotRequiredWithValidation{F1: []string{"a", "b"}}},
+		//{Name: "not enough items", Raw: `{"f1": ["a"]}`, ErrorMsg: "f1: length must be >= 2"}, // TODO: skip validation of optional fields
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			var actual NotRequiredWithValidation
+			err := json.Unmarshal([]byte(tc.Raw), &actual)
+			if tc.ErrorMsg != "" {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, tc.ErrorMsg)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			assert.Equal(t, tc.Expected, actual)
+		})
+	}
+}

--- a/tests/example/openapi.yaml
+++ b/tests/example/openapi.yaml
@@ -947,3 +947,19 @@ components:
         - properties:
             buzz:
               type: string
+
+    DefaultWithoutRequired:
+      type: object
+      properties:
+        f1:
+          type: string
+          default: "surprise!"
+
+    NotRequiredWithValidation:
+      type: object
+      properties:
+        f1:
+          minItems: 2
+          type: array
+          items:
+            type: string


### PR DESCRIPTION
Added a TODO for skipping validation of missing optional fields