### PR TITLE
if a custom-mapped type is an array in a different package, split the…

### DIFF
--- a/foji/openapi/service.go.tpl
+++ b/foji/openapi/service.go.tpl
@@ -26,20 +26,13 @@ package {{ .PackageName }}
 
 import (
 	"context"
+	"errors"
 
 {{- .CheckAllTypes .PackageName ($.Params.GetWithDefault "Auth" "") -}}
 {{ range .GoImports }}
 	"{{ . }}"
 {{- end }}
 )
-
-type Error string
-
-func (e Error) Error() string {
-	return string(e)
-}
-
-const ErrNotImplemented = Error("not implemented")
 
 // New creates a new service instance.
 func New() *Service {
@@ -62,7 +55,7 @@ func (s *Service) {{ pascal $op.OperationID}}(ctx context.Context,
     return 
 	{{- if notEmpty $response -}}nil, {{ end -}}
     {{- if gt (len ($.GetOpHappyResponseHeaders $.PackageName $op)) 0 -}}http.Header{}, {{ end -}} 
-	ErrNotImplemented
+	errors.ErrUnsupported
 }
 	{{- end }}
 {{- end }}

--- a/output/context.go
+++ b/output/context.go
@@ -120,6 +120,7 @@ type Imports stringlist.Strings
 // If the type is defined in a separate package the package is added to the import list.
 func (ii *Imports) CheckPackage(t, currentPackage string) string {
 	arrayPrefix := ""
+
 	if strings.HasPrefix(t, "[]") {
 		t = t[2:]
 		arrayPrefix = "[]"

--- a/output/context.go
+++ b/output/context.go
@@ -119,10 +119,16 @@ type Imports stringlist.Strings
 // "github.com/domain/repo/package/subpackage.Type", "github.com/domain/repo/package/subpackage" => "Type"
 // If the type is defined in a separate package the package is added to the import list.
 func (ii *Imports) CheckPackage(t, currentPackage string) string {
+	arrayPrefix := ""
+	if strings.HasPrefix(t, "[]") {
+		t = t[2:]
+		arrayPrefix = "[]"
+	}
+
 	tt := strings.Split(t, ".")
 	// Base Type
 	if len(tt) == 1 {
-		return t
+		return arrayPrefix + t
 	}
 
 	prefix := ""
@@ -135,7 +141,7 @@ func (ii *Imports) CheckPackage(t, currentPackage string) string {
 
 	// Type defined in same package
 	if typePkg == currentPackage {
-		return prefix + tt[len(tt)-1]
+		return arrayPrefix + prefix + tt[len(tt)-1]
 	}
 
 	// Type defined in external package
@@ -144,10 +150,10 @@ func (ii *Imports) CheckPackage(t, currentPackage string) string {
 	pp := strings.Split(t, "/")
 
 	if len(pp) > 1 {
-		return prefix + pp[len(pp)-1]
+		return arrayPrefix + prefix + pp[len(pp)-1]
 	}
 
-	return t
+	return arrayPrefix + t
 }
 
 // Add filters duplicates and appends to the import list.

--- a/tests/example/http_handler_gen.go
+++ b/tests/example/http_handler_gen.go
@@ -31,7 +31,7 @@ type Operations interface {
 	GetAuthSimple2(ctx context.Context, user *ExampleAuth) error
 	GetAuthSimple2Maybe(ctx context.Context, user *ExampleAuth) error
 	GetAuthComplexMaybe(ctx context.Context, user *ExampleAuth) error
-	GetComplexSecurity(ctx context.Context, user *ExampleAuth) error
+	GetComplexSecurity(ctx context.Context, user *ExampleAuth) ([]TestInt, error)
 	AddForm(ctx context.Context, body AddFormRequest) (*FooBar, error)
 	AddMultipartForm(ctx context.Context, body AddMultipartFormRequest) (*FooBar, error)
 	HeaderResponse(ctx context.Context) (http.Header, error)
@@ -307,14 +307,14 @@ func (h OpenAPIHandlers) GetComplexSecurity(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	err = h.ops.GetComplexSecurity(r.Context(), user)
+	response, err := h.ops.GetComplexSecurity(r.Context(), user)
 	if err != nil {
 		httputil.ErrorHandler(w, r, err)
 
 		return
 	}
 
-	w.WriteHeader(200)
+	httputil.JSONWrite(w, r, 200, response)
 }
 
 // AddForm

--- a/tests/example/openapi.yaml
+++ b/tests/example/openapi.yaml
@@ -659,6 +659,15 @@ paths:
       responses:
         "200":
           description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  description: Sample mapping int to custom type
+                  type: integer
+                  format: int32
+                  x-go-type: TestInt
 components:
   securitySchemes:
     HeaderAuth:

--- a/tests/example/service.go
+++ b/tests/example/service.go
@@ -12,6 +12,8 @@ type ExampleAuth struct{}
 
 type Service struct{}
 
+type TestInt int32
+
 func (s *Service) GetExamples(ctx context.Context) (*Examples, error) {
 	return nil, nil
 }
@@ -96,4 +98,6 @@ func (s *Service) HeaderResponse(ctx context.Context) (http.Header, error) {
 	return nil, nil
 }
 
-func (s *Service) GetComplexSecurity(ctx context.Context, user *ExampleAuth) error { return nil }
+func (s *Service) GetComplexSecurity(ctx context.Context, user *ExampleAuth) ([]TestInt, error) {
+	return nil, nil
+}


### PR DESCRIPTION
… package checking and then add the array prefix back

remove custom ErrNotImplemented for errors.ErrUnsupported