### PR TITLE
Choose Op Happy Response deterministically

### DIFF
--- a/output/openapi.go
+++ b/output/openapi.go
@@ -470,48 +470,58 @@ func happyStatusCode(key string) bool {
 	return key[0] == '2' || key[0] == '3'
 }
 
-//nolint:gocognit
 func (o *OpenAPIFileContext) GetOpHappyResponse(pkg string, op *openapi3.Operation) OpResponse {
 	supportedResponseContentTypes := []string{ApplicationJSON, ApplicationJSONL, TextPlain, TextHTML, TextCSV}
 
+	// kin-openapi does not preserve response ordering so we order here by "happy key"
+	// to make sure we choose a happy response deterministically
+
+	happyKeys := []string{}
+
+	for key := range op.Responses.Map() {
+		if happyStatusCode(key) {
+			happyKeys = append(happyKeys, key)
+		}
+	}
+
+	slices.Sort(happyKeys)
+
 	happyKey := "200"
 
-	for key, r := range op.Responses.Map() {
-		if happyStatusCode(key) { //nolint:nestif
-			happyKey = key
+	for _, key := range happyKeys {
+		r := op.Responses.Map()[key]
+		for _, mimeType := range supportedResponseContentTypes {
+			mediaType := r.Value.Content.Get(mimeType)
+			if mediaType != nil {
+				mime := MimeType(mimeType)
+				t := o.GetType(pkg, kace.Pascal(op.OperationID)+" Response", mediaType.Schema)
 
-			for _, mimeType := range supportedResponseContentTypes {
-				mediaType := r.Value.Content.Get(mimeType)
-				if mediaType != nil {
-					mime := MimeType(mimeType)
-					t := o.GetType(pkg, kace.Pascal(op.OperationID)+" Response", mediaType.Schema)
-
-					if t == "" {
-						// Unknown type, use []byte by default
-						t = "[]byte"
-					}
-
-					var goType string
-
-					if strings.HasPrefix(t, "[]") || strings.HasPrefix(t, "map[") || slices.Contains(knownInterfaces, t) {
-						goType = t
-					} else {
-						goType = "*" + t
-					}
-
-					if r.Value.Headers != nil {
-						return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: slices.Collect(maps.Keys(r.Value.Headers))}
-					}
-
-					return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: []string{}}
+				if t == "" {
+					// Unknown type, use []byte by default
+					t = "[]byte"
 				}
+
+				var goType string
+
+				if strings.HasPrefix(t, "[]") || strings.HasPrefix(t, "map[") || slices.Contains(knownInterfaces, t) {
+					goType = t
+				} else {
+					goType = "*" + t
+				}
+
+				if r.Value.Headers != nil {
+					return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: slices.Collect(maps.Keys(r.Value.Headers))}
+				}
+
+				return OpResponse{Key: key, MimeType: mime, MediaType: mediaType, GoType: goType, Headers: []string{}}
 			}
 		}
 	}
 
 	// No response with a supported content type found, but maybe there's a response with headers only
-	for key, r := range op.Responses.Map() {
-		if happyStatusCode(key) && len(r.Value.Headers) > 0 {
+	for _, key := range happyKeys {
+		r := op.Responses.Map()[key]
+		if len(r.Value.Headers) > 0 {
 			return OpResponse{Key: key, MimeType: "", MediaType: nil, GoType: "", Headers: slices.Collect(maps.Keys(r.Value.Headers))}
 		}
 	}

--- a/output/openapi_test.go
+++ b/output/openapi_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/gofoji/foji/stringlist"
 )
 
+func TestGetOpHappyResponse(t *testing.T) {
+	doc, err := openapi3.NewLoader().LoadFromFile("testdata/openapi.yaml")
+	require.NoError(t, err)
+	ctx := getContext(doc)
+	got := ctx.GetOpHappyResponse("", ctx.API.Paths.Find("/examples/with-auth").Get)
+	assert.Equal(t, "200", got.Key)
+}
+
 func TestGetType(t *testing.T) {
 	doc, err := openapi3.NewLoader().LoadFromFile("testdata/openapi.yaml")
 	require.NoError(t, err)

--- a/output/testdata/openapi.yaml
+++ b/output/testdata/openapi.yaml
@@ -2,7 +2,23 @@ openapi: 3.0.2
 info:
   title: "Test"
   version: "1.0"
-paths: {}
+
+paths:
+  /examples/with-auth:
+    get:
+      operationId: withAuth
+      security:
+        - HeaderAuth: ["foo"]
+        - HeaderAuth: ["bar"]
+        - Jwt: []
+      responses:
+        "307":
+          description: 'Temporary redirect'
+        "308":
+          description: 'Permanent redirect'
+        "200":
+          description: OK
+
 components:
   schemas:
     MapTest:


### PR DESCRIPTION
If the openapi spec defines an authenticated operation with multiple 200-399 response codes (like we do in the "shortener" service) then foji picks a response non-deterministically. The root cause is that kin-openapi uses a map to store the responses and so we iterate them in random order.

This commit changes GetOpHappyResponse to sort the possible happy responses lexographically so that we always return the same one for any given input. It also means that when "200" is available, it is always chosen as the default even if other happy responses are available.