### PR TITLE
Allow URLs as file source, including github API urls

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -28,6 +28,10 @@ type (
 	FileInput struct {
 		// Files to process, supports glob syntax https://golang.org/pkg/path/filepath/#Match
 		Files stringlist.Strings
+		// Files to process from abitrary URL
+		Urls stringlist.Strings `yaml:"urls,omitempty"`
+		// Files to process from github. This is the same as [Urls], except that it adds github API specific headers. Use syntax https://api.github.com/repos/ORG/REPO/contents/PATH/TO/FILE?ref=TAG
+		GithubFiles stringlist.Strings `yaml:"githubFiles,omitempty"`
 		// Optional regex for filtering the files.  The filename must not match any of the filter
 		// expressions to be considered valid.
 		Filter  stringlist.Strings   `yaml:"filter,omitempty"`
@@ -173,5 +177,5 @@ func (o Output) All() stringlist.StringMap {
 
 // IsEmpty checks Files globs.
 func (f FileInput) IsEmpty() bool {
-	return len(f.Files) == 0
+	return len(f.Files) == 0 && len(f.GithubFiles) == 0
 }

--- a/cfg/merge.go
+++ b/cfg/merge.go
@@ -158,7 +158,7 @@ func (ff FileInputMap) Merge(from FileInputMap) FileInputMap {
 
 // Merge merges all properties from an ancestor FileInput.
 func (f FileInput) Merge(from FileInput) FileInput {
-	if len(f.Files) > 0 || len(f.Filter) > 0 || len(f.Rewrite) > 0 {
+	if len(f.Files) > 0 || len(f.GithubFiles) > 0 || len(f.Filter) > 0 || len(f.Rewrite) > 0 {
 		return f
 	}
 

--- a/input/files.go
+++ b/input/files.go
@@ -2,7 +2,10 @@ package input
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"regexp"
 
@@ -11,6 +14,11 @@ import (
 	"github.com/gofoji/foji/cfg"
 	"github.com/gofoji/foji/files"
 	"github.com/gofoji/foji/stringlist"
+)
+
+var (
+	ErrNoGithubToken    = errors.New("missing github authentication token")
+	ErrGithubStatusCode = errors.New("github returned non-successful status")
 )
 
 type FileGroup struct {
@@ -36,8 +44,33 @@ func rewrite(rules stringlist.StringMap, name string) string {
 	return name
 }
 
-func Parse(_ context.Context, logger zerolog.Logger, input cfg.FileInput) (FileGroup, error) {
+func Parse(ctx context.Context, logger zerolog.Logger, input cfg.FileInput) (FileGroup, error) {
 	result := FileGroup{FileInput: input}
+
+	fileResults, err := ParseFiles(ctx, logger, input)
+	if err != nil {
+		return result, err
+	}
+
+	urlResults, err := ParseUrls(ctx, logger, input)
+	if err != nil {
+		return result, err
+	}
+
+	githubResults, err := ParseGithubFiles(ctx, logger, input)
+	if err != nil {
+		return result, err
+	}
+
+	result.Files = append(result.Files, fileResults...)
+	result.Files = append(result.Files, urlResults...)
+	result.Files = append(result.Files, githubResults...)
+
+	return result, nil
+}
+
+func ParseFiles(_ context.Context, logger zerolog.Logger, input cfg.FileInput) ([]File, error) {
+	result := []File{}
 
 	loadedFiles := stringlist.Strings{}
 
@@ -87,9 +120,100 @@ func Parse(_ context.Context, logger zerolog.Logger, input cfg.FileInput) (FileG
 				Content: b,
 			}
 			logger.Debug().Str("name", file.Name).Msg("File Loaded")
-			result.Files = append(result.Files, file)
+			result = append(result, file)
 			loadedFiles = append(loadedFiles, filename)
 		}
+	}
+
+	return result, nil
+}
+
+func ParseGithubFiles(ctx context.Context, logger zerolog.Logger, input cfg.FileInput) ([]File, error) {
+	result := []File{}
+
+	githubToken, ok := os.LookupEnv("GH_TOKEN")
+
+	if !ok && len(input.GithubFiles) > 0 {
+		return result, ErrNoGithubToken
+	}
+
+	for _, u := range input.GithubFiles {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return result, fmt.Errorf("error creating request to read url: %s: %w", u, err)
+		}
+
+		req.Header.Add("Accept", "application/vnd.github.raw+json")
+		req.Header.Add("Authorization", "Bearer "+githubToken)
+
+		logger.Debug().Str("source", u).Msg("Fetching URL")
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return result, fmt.Errorf("error fetching url: %s: %w", u, err)
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return result, fmt.Errorf("%w %d for url %s", ErrGithubStatusCode, res.StatusCode, u)
+		}
+
+		logger.Debug().Str("source", u).Msg("Reading URL")
+
+		b, err := io.ReadAll(res.Body)
+		if err != nil {
+			return result, fmt.Errorf("error reading body: %s: %w", u, err)
+		}
+
+		file := File{
+			Source:  u,
+			Name:    rewrite(input.Rewrite, u),
+			Content: b,
+		}
+		logger.Debug().Str("name", file.Name).Msg("File Loaded")
+		result = append(result, file)
+	}
+
+	return result, nil
+}
+
+func ParseUrls(ctx context.Context, logger zerolog.Logger, input cfg.FileInput) ([]File, error) {
+	result := []File{}
+
+	for _, u := range input.Urls {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return result, fmt.Errorf("error creating request to read url: %s: %w", u, err)
+		}
+
+		logger.Debug().Str("source", u).Msg("Fetching URL")
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return result, fmt.Errorf("error fetching url: %s: %w", u, err)
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode != http.StatusOK {
+			return result, fmt.Errorf("%w %d for url %s", ErrGithubStatusCode, res.StatusCode, u)
+		}
+
+		logger.Debug().Str("source", u).Msg("Reading URL")
+
+		b, err := io.ReadAll(res.Body)
+		if err != nil {
+			return result, fmt.Errorf("error reading body: %s: %w", u, err)
+		}
+
+		file := File{
+			Source:  u,
+			Name:    rewrite(input.Rewrite, u),
+			Content: b,
+		}
+		logger.Debug().Str("name", file.Name).Msg("File Loaded")
+		result = append(result, file)
 	}
 
 	return result, nil


### PR DESCRIPTION
Motivation: https://github.com/gofoji/foji/pull/71 allows generating API clients from an openapi spec, however it may not be desirable to vendor the openapi spec. An example use-case is if you have microservices in different github repos, you may not want to copy the api spec into every callee service.

Solution: foji.yaml can reference a URL instead of a local file. This also supportes "github files" which is a URL to the github API for fetching an individual file contents, to which foji will manage adding auth and accept headers.  It is *STRONGLY* recommended to use a URL whose contents will not change, for example by embedding a tag into a github URL.